### PR TITLE
Refactor: reset input and mouse exit

### DIFF
--- a/src/components/Controls/SearchScreen/ListItem.svelte
+++ b/src/components/Controls/SearchScreen/ListItem.svelte
@@ -16,7 +16,7 @@
 	.list-item {
 		@apply hover:text-yellow-500 transform-gpu transition-all duration-150 text-2xl;
 		@apply cursor-pointer relative;
-		@apply p-4 w-full text-left active:opacity-50;
+		@apply p-4 w-fit select-none text-left active:opacity-50;
 		@apply flex flex-row gap-2 justify-between items-start;
 
 		&:hover:before {

--- a/src/components/Controls/SearchScreen/SearchScreen.svelte
+++ b/src/components/Controls/SearchScreen/SearchScreen.svelte
@@ -10,6 +10,10 @@
 	function handleBGClick() {
 		open = false;
 	}
+
+	$: if (!open) {
+		searchQuery = '';
+	}
 </script>
 
 <FullScreenOverlay bind:open>
@@ -32,8 +36,8 @@
 				/>
 			</div>
 
-			<div class="w-full flex-grow relative">
-				<div class="flex absolute inset-0 overflow-y-scroll flex-col gap-4 p-8 w-full flex-grow">
+			<div class="w-full flex-grow relative" on:click={handleBGClick} on:keydown={handleBGClick}>
+				<div class="flex absolute inset-0 overflow-y-scroll flex-col gap-4 p-8 w-fit flex-grow">
 					<slot />
 				</div>
 			</div>


### PR DESCRIPTION
Implements 2 changes:
- resets the input for each new menu opening
- expands the area to click outside the menu (feel this is more natural than an element taking the whole width)

side by side:


https://github.com/Nickersoft/cityhop.cafe/assets/45521157/6a917b49-026f-4feb-913e-6e261ee0b767



