### PR TITLE
Fix: update Synthwave station trackID

### DIFF
--- a/src/data/stations.ts
+++ b/src/data/stations.ts
@@ -86,7 +86,7 @@ const stations = {
   },
   "Synthwave Radio": {
     name: "synthwave radio 🌌 - beats to chill/game to",
-    trackID: "MVPTGNGiI-4",
+    trackID: "4xDzrJKXOOY",
     genre: Genre.electronic,
     live: true,
   },


### PR DESCRIPTION
Fixes VaporFunk and Synthwave trackIDs because at the moment, they're pointing to videos that are no longer available.

Also, thanks for making such a cool thing!